### PR TITLE
Fix player character variable typos

### DIFF
--- a/BattleScene.cs
+++ b/BattleScene.cs
@@ -13,19 +13,19 @@ public partial class BattleScene : Control
     private BattleManager battleManager;
     
      private Action onBattleFinished;
-    public void Setup(List<CharacterData> playercharackters, List<CharacterData> enemies, Action onFinishedCallback)
+    public void Setup(List<CharacterData> playerCharacters, List<CharacterData> enemies, Action onFinishedCallback)
     {
         this.onBattleFinished = onFinishedCallback;
-        foreach (var playercharackter in playercharackters)
-        {   
-            AddCharacterNode(playercharackter, isPlayer: true);
+        foreach (var playerCharacter in playerCharacters)
+        {
+            AddCharacterNode(playerCharacter, isPlayer: true);
         }
         foreach (var enemy in enemies)
         {
             enemyNodes.Add(CharacterNode.Create(enemy));
             AddCharacterNode(enemy, isPlayer: false);
         }        
-        battleManager = new BattleManager(playercharackters, enemies, BattleLog, onFinishedCallback);
+        battleManager = new BattleManager(playerCharacters, enemies, BattleLog, onFinishedCallback);
     }
      private void AddCharacterNode(CharacterData data, bool isPlayer)
     {

--- a/Game.cs
+++ b/Game.cs
@@ -15,7 +15,7 @@ public partial class Game : Control
 
     }
 
-    public void StartBattle(List<CharacterData> playercharackters, List<CharacterData> enemies)
+    public void StartBattle(List<CharacterData> playerCharacters, List<CharacterData> enemies)
     {
         if (previousContent != null)
             previousContent.Visible = false;
@@ -23,7 +23,7 @@ public partial class Game : Control
         var scene = GD.Load<PackedScene>("res://scenes/battle/BattleScene.tscn");
         battleScene = scene.Instantiate<BattleScene>();
         // Optional: Charakterdaten an Szene übergeben
-        battleScene.Setup(playercharackters, enemies, OnBattleFinished);
+        battleScene.Setup(playerCharacters, enemies, OnBattleFinished);
 
         MainContent.AddChild(battleScene);
     }

--- a/Scripts/battlesystem/BattleManager.cs
+++ b/Scripts/battlesystem/BattleManager.cs
@@ -5,16 +5,16 @@ using Godot;
 
 public class BattleManager
 {
-    private List<CharacterData> playercharackters;
+    private List<CharacterData> playerCharacters;
     private List<CharacterData> enemies;
     private RichTextLabel log;
     private Action onFinishedCallback;
     private int currentEnemyIndex = 0;
     private bool playerTurn = true;
 
-    public BattleManager(List<CharacterData> playercharackters, List<CharacterData> enemies, RichTextLabel log, Action onFinishedCallback)
+    public BattleManager(List<CharacterData> playerCharacters, List<CharacterData> enemies, RichTextLabel log, Action onFinishedCallback)
     {
-        this.playercharackters = playercharackters;
+        this.playerCharacters = playerCharacters;
         this.enemies = enemies;
         this.log = log;
         this.onFinishedCallback = onFinishedCallback;
@@ -28,7 +28,7 @@ public class BattleManager
     public void ExecuteTurn()
     {
 
-        if (playercharackters.All(p => p.IsDead) || enemies.All(p => p.IsDead))
+        if (playerCharacters.All(p => p.IsDead) || enemies.All(p => p.IsDead))
         {
             log.AppendText("\nDer Kampf ist vorbei.");
             return;
@@ -38,16 +38,16 @@ public class BattleManager
         // if (playerTurn)
         // {
         //     var target = enemies[currentEnemyIndex % enemies.Count];
-        //     int damage = Mathf.Max(0, playercharackters.Attack - target.Defence);
+        //     int damage = Mathf.Max(0, playerCharacters.Attack - target.Defence);
         //     target.CurrentHP -= damage;
-        //     log.AppendText($"\n{playercharackters.Name} greift {target.Name} an für {damage} Schaden!");
+        //     log.AppendText($"\n{playerCharacters.Name} greift {target.Name} an für {damage} Schaden!");
         // }
         // else
         // {
         //     var attacker = enemies[currentEnemyIndex % enemies.Count];
-        //     int damage = Mathf.Max(0, attacker.Attack - playercharackters.Defence);
-        //     playercharackters.CurrentHP -= damage;
-        //     log.AppendText($"\n{attacker.Name} greift {playercharackters.Name} an für {damage} Schaden!");
+        //     int damage = Mathf.Max(0, attacker.Attack - playerCharacters.Defence);
+        //     playerCharacters.CurrentHP -= damage;
+        //     log.AppendText($"\n{attacker.Name} greift {playerCharacters.Name} an für {damage} Schaden!");
         // }
 
         playerTurn = !playerTurn;


### PR DESCRIPTION
## Summary
- rename `playercharackters` typo to `playerCharacters` across codebase
- rename `playercharackter` variable in loops to `playerCharacter`
- update comments accordingly
- compile with dotnet to ensure no build errors

## Testing
- `dotnet build "Rundenbasiertes kampfsystem prototyp.sln" -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68420d03cbb48332a8069a9824c03f05