### PR TITLE
Implement CTB timeline

### DIFF
--- a/Scripts/battlesystem/BattleManager.cs
+++ b/Scripts/battlesystem/BattleManager.cs
@@ -9,8 +9,13 @@ public class BattleManager
     private List<CharacterData> enemies;
     private RichTextLabel log;
     private Action onFinishedCallback;
-    private int currentEnemyIndex = 0;
-    private bool playerTurn = true;
+    private Dictionary<CharacterData, int> initiativeGauge = new();
+    private List<CharacterData> allCharacters = new();
+
+    /// <summary>
+    /// Contains the next characters that will act. Updated after each turn.
+    /// </summary>
+    public List<CharacterData> UpcomingTurns { get; private set; } = new();
 
     public BattleManager(List<CharacterData> playerCharacters, List<CharacterData> enemies, RichTextLabel log, Action onFinishedCallback)
     {
@@ -18,11 +23,59 @@ public class BattleManager
         this.enemies = enemies;
         this.log = log;
         this.onFinishedCallback = onFinishedCallback;
+
+        allCharacters.AddRange(playerCharacters);
+        allCharacters.AddRange(enemies);
+
+        foreach (var ch in allCharacters)
+        {
+            initiativeGauge[ch] = 0;
+        }
+
+        UpcomingTurns = PredictTurns(10);
     }
 
-    public void CalculateTurnOrder()
+    private int GetThreshold(Dictionary<CharacterData, int> gauge, Dictionary<CharacterData, int> rounds)
     {
-        var chars = new List<CharacterData>();
+        return allCharacters
+            .Where(c => c.IsAlive)
+            .Select(c => c.GetSpeed(rounds[c]))
+            .DefaultIfEmpty(0)
+            .Max() * 100;
+    }
+
+    private CharacterData StepTurn(Dictionary<CharacterData, int> gauge, Dictionary<CharacterData, int> rounds)
+    {
+        while (true)
+        {
+            int threshold = GetThreshold(gauge, rounds);
+
+            foreach (var ch in allCharacters.Where(c => c.IsAlive))
+            {
+                gauge[ch] += ch.GetSpeed(rounds[ch]);
+                if (gauge[ch] >= threshold)
+                {
+                    gauge[ch] -= threshold;
+                    rounds[ch]++;
+                    return ch;
+                }
+            }
+        }
+    }
+
+    private List<CharacterData> PredictTurns(int count)
+    {
+        var gaugeCopy = new Dictionary<CharacterData, int>(initiativeGauge);
+        var roundCopy = allCharacters.ToDictionary(c => c, c => c.Round);
+        var result = new List<CharacterData>();
+
+        for (int i = 0; i < count; i++)
+        {
+            var next = StepTurn(gaugeCopy, roundCopy);
+            result.Add(next);
+        }
+
+        return result;
     }
 
     public void ExecuteTurn()
@@ -34,24 +87,12 @@ public class BattleManager
             return;
         }
 
+        var rounds = allCharacters.ToDictionary(c => c, c => c.Round);
+        var actor = StepTurn(initiativeGauge, rounds);
+        actor.AdvanceRound();
 
-        // if (playerTurn)
-        // {
-        //     var target = enemies[currentEnemyIndex % enemies.Count];
-        //     int damage = Mathf.Max(0, playerCharacters.Attack - target.Defence);
-        //     target.CurrentHP -= damage;
-        //     log.AppendText($"\n{playerCharacters.Name} greift {target.Name} an für {damage} Schaden!");
-        // }
-        // else
-        // {
-        //     var attacker = enemies[currentEnemyIndex % enemies.Count];
-        //     int damage = Mathf.Max(0, attacker.Attack - playerCharacters.Defence);
-        //     playerCharacters.CurrentHP -= damage;
-        //     log.AppendText($"\n{attacker.Name} greift {playerCharacters.Name} an für {damage} Schaden!");
-        // }
+        log.AppendText($"\n{actor.Name} ist am Zug.");
 
-        playerTurn = !playerTurn;
-        if (!playerTurn)
-            currentEnemyIndex++;
+        UpcomingTurns = PredictTurns(10);
     }
 }

--- a/Scripts/battlesystem/CharacterData.cs
+++ b/Scripts/battlesystem/CharacterData.cs
@@ -11,6 +11,11 @@ public class CharacterData
 
     public CharacterNode Node { get; set; }
 
+    /// <summary>
+    /// Number of turns this character has already taken.
+    /// </summary>
+    public int Round { get; private set; }
+
     public CharacterData(string name, int maxHP, int maxMana, int speed, int attack, int defence)
     {
         Name = name;
@@ -26,5 +31,21 @@ public class CharacterData
     public bool IsAlive => CurrentHP > 0;
 
     public bool IsDead => CurrentHP <= 0;
+
+    /// <summary>
+    /// Returns the effective speed for the specified round.
+    /// Currently this is the base speed but will later include buffs or debuffs.
+    /// </summary>
+    public int GetSpeed(int round) => Speed;
+
+    /// <summary>
+    /// Returns the effective speed for the current round.
+    /// </summary>
+    public int GetCurrentSpeed() => GetSpeed(Round);
+
+    /// <summary>
+    /// Increments the internal round counter.
+    /// </summary>
+    public void AdvanceRound() => Round++;
    
 }

--- a/tests/Rundenbasierteskampfsystemprototyp.Tests/BattleManagerTests.cs
+++ b/tests/Rundenbasierteskampfsystemprototyp.Tests/BattleManagerTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+public class BattleManagerTests
+{
+    [Fact]
+    public void PredictTurns_Uses_Speed_For_Order()
+    {
+        var a = new CharacterData("A", 10, 5, 10, 1, 1);
+        var b = new CharacterData("B", 10, 5, 5, 1, 1);
+        var manager = new BattleManager(new List<CharacterData>{a}, new List<CharacterData>{b}, null!, () => { });
+        var order = manager.UpcomingTurns.Take(6).ToList();
+        Assert.Equal(new[]{a, a, b, a, a, b}, order);
+    }
+}

--- a/tests/Rundenbasierteskampfsystemprototyp.Tests/CharacterDataTests.cs
+++ b/tests/Rundenbasierteskampfsystemprototyp.Tests/CharacterDataTests.cs
@@ -14,4 +14,19 @@ public class CharacterDataTests
         Assert.Equal(expectedAlive, character.IsAlive);
         Assert.Equal(expectedDead, character.IsDead);
     }
+
+    [Fact]
+    public void GetSpeed_Returns_BaseSpeed()
+    {
+        var character = new CharacterData("Test", 10, 5, 7, 1, 1);
+        Assert.Equal(7, character.GetSpeed(0));
+    }
+
+    [Fact]
+    public void AdvanceRound_Increments_Round()
+    {
+        var character = new CharacterData("Test", 10, 5, 7, 1, 1);
+        character.AdvanceRound();
+        Assert.Equal(1, character.Round);
+    }
 }


### PR DESCRIPTION
## Summary
- implement CTB algorithm in `BattleManager`
- add round-aware speed getter to `CharacterData`
- provide unit tests for `BattleManager` and `CharacterData`

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684217b42f8c83329d472ec15fb2f140