### PR TITLE
Add hover-based outline and green highlight

### DIFF
--- a/Scripts/battlesystem/CharacterNode.cs
+++ b/Scripts/battlesystem/CharacterNode.cs
@@ -5,7 +5,10 @@ using System.Runtime.CompilerServices;
 public partial class CharacterNode : Node2D
 {
     [Export] public Texture2D CharacterImage;
-    private TextureRect _image;
+    private Sprite2D _sprite;
+    private ShaderMaterial _shader;
+    private bool _isHovered = false;
+    private bool _isCurrentFighter = false;
     private ProgressBar _hpBar;
     private ProgressBar _manaBar;
 
@@ -13,16 +16,60 @@ public partial class CharacterNode : Node2D
 
     public override void _Ready()
     {
-        _image = GetNode<TextureRect>("%CharacterTexture");
+        _sprite = GetNode<Sprite2D>("%CharacterSprite");
+        _shader = _sprite.Material as ShaderMaterial;
         _hpBar = GetNode<ProgressBar>("%HPBar");
         _manaBar = GetNode<ProgressBar>("%ManaBar");
 
         if (CharacterImage != null)
-            _image.Texture = CharacterImage;
+            _sprite.Texture = CharacterImage;
+
+        _sprite.Connect("mouse_entered", new Callable(this, nameof(OnMouseEntered)));
+        _sprite.Connect("mouse_exited", new Callable(this, nameof(OnMouseExited)));
 
         UpdateUI();
+        UpdateOutline();
     }
 
+    private void OnMouseEntered()
+    {
+        _isHovered = true;
+        UpdateOutline();
+    }
+
+    private void OnMouseExited()
+    {
+        _isHovered = false;
+        UpdateOutline();
+    }
+
+    public void SetCurrentFighter(bool value)
+    {
+        _isCurrentFighter = value;
+        UpdateOutline();
+    }
+
+    private void UpdateOutline()
+    {
+        if (_shader == null) return;
+
+        if (_isCurrentFighter)
+        {
+            _shader.SetShaderParameter("line_color", new Color(0, 1, 0, 1));
+            _shader.SetShaderParameter("line_thickness", 10.0f);
+            return;
+        }
+
+        if (_isHovered)
+        {
+            _shader.SetShaderParameter("line_color", new Color(1, 1, 1, 1));
+            _shader.SetShaderParameter("line_thickness", 10.0f);
+        }
+        else
+        {
+            _shader.SetShaderParameter("line_thickness", 0.0f);
+        }
+    }
     public void SetData(CharacterData data)
     {
         Data = data;

--- a/Scripts/battlesystem/CharacterNode.tscn
+++ b/Scripts/battlesystem/CharacterNode.tscn
@@ -57,6 +57,7 @@ shape = SubResource("CapsuleShape2D_o6dxo")
 
 [node name="CharacterSprite" type="Sprite2D" parent="CharacterBody2D"]
 unique_name_in_owner = true
+input_pickable = true
 material = SubResource("ShaderMaterial_o6dxo")
 position = Vector2(109, 210)
 scale = Vector2(0.184, 0.19)


### PR DESCRIPTION
## Summary
- support mouse hover highlighting on CharacterSprite
- show green outline when a character is the current fighter

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684218bc37fc8332bb79b6603a46c3ca