### PR TITLE
Add buff system and attack logic

### DIFF
--- a/Scripts/battlesystem/Buff.cs
+++ b/Scripts/battlesystem/Buff.cs
@@ -1,0 +1,21 @@
+public class Buff
+{
+    public CharacterStat TargetStat { get; }
+    public float Factor { get; }
+    public int Value { get; }
+    public int StartTurn { get; }
+    public int EndTurn { get; }
+    public string Icon { get; }
+
+    public Buff(CharacterStat stat, float factor, int value, int startTurn, int endTurn, string icon = "")
+    {
+        TargetStat = stat;
+        Factor = factor;
+        Value = value;
+        StartTurn = startTurn;
+        EndTurn = endTurn;
+        Icon = icon;
+    }
+
+    public bool IsActive(int round) => round >= StartTurn && round < EndTurn;
+}

--- a/Scripts/battlesystem/CharacterData.cs
+++ b/Scripts/battlesystem/CharacterData.cs
@@ -1,3 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+public enum CharacterStat
+{
+    Speed,
+    Attack,
+    Defence,
+    MaxHP,
+    CurrentHP,
+    MaxMana,
+    CurrentMana
+}
+
 public class CharacterData
 {
     public string Name { get; set; }
@@ -10,6 +24,8 @@ public class CharacterData
     public int Defence { get; set; }
 
     public CharacterNode Node { get; set; }
+
+    private readonly List<Buff> buffs = new();
 
     /// <summary>
     /// Number of turns this character has already taken.
@@ -36,16 +52,62 @@ public class CharacterData
     /// Returns the effective speed for the specified round.
     /// Currently this is the base speed but will later include buffs or debuffs.
     /// </summary>
-    public int GetSpeed(int round) => Speed;
+    public int GetSpeed(int round) => GetStat(CharacterStat.Speed, round);
+
+    public int GetStat(CharacterStat stat, int round)
+    {
+        int baseValue = stat switch
+        {
+            CharacterStat.Speed => Speed,
+            CharacterStat.Attack => Attack,
+            CharacterStat.Defence => Defence,
+            CharacterStat.MaxHP => MaxHP,
+            CharacterStat.CurrentHP => CurrentHP,
+            CharacterStat.MaxMana => MaxMana,
+            CharacterStat.CurrentMana => CurrentMana,
+            _ => 0
+        };
+
+        var bonus = 0f;
+        foreach (var buff in buffs)
+        {
+            if (buff.TargetStat == stat && buff.IsActive(round))
+            {
+                bonus += baseValue * buff.Factor + buff.Value;
+            }
+        }
+
+        return (int)MathF.Round(baseValue + bonus);
+    }
+
+    public int GetCurrentStat(CharacterStat stat) => GetStat(stat, Round);
 
     /// <summary>
     /// Returns the effective speed for the current round.
     /// </summary>
     public int GetCurrentSpeed() => GetSpeed(Round);
 
+    public int GetAttack(int round) => GetStat(CharacterStat.Attack, round);
+
+    public int GetCurrentAttack() => GetAttack(Round);
+
+    public int GetDefence(int round) => GetStat(CharacterStat.Defence, round);
+
+    public int GetCurrentDefence() => GetDefence(Round);
+
     /// <summary>
     /// Increments the internal round counter.
     /// </summary>
     public void AdvanceRound() => Round++;
+
+    public void AddBuff(Buff buff)
+    {
+        buffs.Add(buff);
+    }
+
+    public void RemoveExpiredBuffs(int round)
+    {
+        buffs.RemoveAll(b => !b.IsActive(round));
+    }
    
 }


### PR DESCRIPTION
## Summary
- introduce `CharacterStat` enum for dynamic stat retrieval
- add `Buff` class and buff handling in `CharacterData`
- implement attack, guard and skip actions in `BattleManager`
- adjust `ExecuteTurn` to apply buffs and perform default attacks

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684220b586a08332b2c401f48145ee94