### PR TITLE
Fix battle scene loading and start combat

### DIFF
--- a/BattleScene.cs
+++ b/BattleScene.cs
@@ -56,7 +56,8 @@ public partial class BattleScene : Control
 
     public override void _Ready()
     {
-
+        if (NextTurnButton != null)
+            NextTurnButton.Pressed += OnNextTurn;
     }
 
     private void OnNextTurn()

--- a/Game.cs
+++ b/Game.cs
@@ -20,7 +20,7 @@ public partial class Game : Control
         if (previousContent != null)
             previousContent.Visible = false;
 
-        var scene = GD.Load<PackedScene>("res://scenes/battle/BattleScene.tscn");
+        var scene = GD.Load<PackedScene>("res://battle_scene.tscn");
         battleScene = scene.Instantiate<BattleScene>();
         // Optional: Charakterdaten an Szene übergeben
         battleScene.Setup(playerCharacters, enemies, OnBattleFinished);
@@ -42,8 +42,15 @@ public partial class Game : Control
     internal void _on_btn_kampf_1_pressed()
     {
 
+        var playerImage = GD.Load<Texture2D>("res://assets/Example_Character_1.png");
+        var bearImage = GD.Load<Texture2D>("res://assets/Bär in Bewegung.png");
+        var wolfImage = GD.Load<Texture2D>("res://assets/Wolf in schwarzem Silhouettenprofil.png");
 
+        var player = new CharacterData("Held", 100, 20, 15, 15, 15, playerImage);
+        var bear = new CharacterData("Bär", 200, 0, 5, 8, 10, bearImage);
+        var wolf = new CharacterData("Wolf", 50, 0, 20, 5, 5, wolfImage);
 
+        StartBattle(new List<CharacterData> { player }, new List<CharacterData> { bear, wolf });
 
     }
 

--- a/Scripts/battlesystem/CharacterData.cs
+++ b/Scripts/battlesystem/CharacterData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Godot;
 
 public enum CharacterStat
 {
@@ -23,6 +24,8 @@ public class CharacterData
     public int Attack { get; set; }
     public int Defence { get; set; }
 
+    public Texture2D? CharacterImage { get; set; }
+
     public CharacterNode Node { get; set; }
 
     private readonly List<Buff> buffs = new();
@@ -32,7 +35,7 @@ public class CharacterData
     /// </summary>
     public int Round { get; private set; }
 
-    public CharacterData(string name, int maxHP, int maxMana, int speed, int attack, int defence)
+    public CharacterData(string name, int maxHP, int maxMana, int speed, int attack, int defence, Texture2D? characterImage = null)
     {
         Name = name;
         MaxHP = maxHP;
@@ -42,6 +45,7 @@ public class CharacterData
         Speed = speed;
         Attack = attack;
         Defence = defence;
+        CharacterImage = characterImage;
     }
 
     public bool IsAlive => CurrentHP > 0;

--- a/Scripts/battlesystem/CharacterNode.cs
+++ b/Scripts/battlesystem/CharacterNode.cs
@@ -74,6 +74,8 @@ public partial class CharacterNode : Node2D
     {
         Data = data;
         data.Node = this;
+        if (data.CharacterImage != null)
+            CharacterImage = data.CharacterImage;
         UpdateUI();
     }
 

--- a/battle_scene.tscn
+++ b/battle_scene.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://b4fruhiln6u1j"]
+[gd_scene load_steps=2 format=3 uid="uid://b4fruhiln6u1j"]
 
 [ext_resource type="Script" uid="uid://dmbofxtd22j8v" path="res://BattleScene.cs" id="1_fw8re"]
-[ext_resource type="PackedScene" uid="uid://8w35m878oka8" path="res://Scripts/battlesystem/CharacterNode.tscn" id="2_r5l0u"]
 
 [node name="BattleScene" type="Control"]
 layout_mode = 3
@@ -11,6 +10,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_fw8re")
+Map = NodePath("Battlers")
+BattleLog = NodePath("BattleLog")
+NextTurnButton = NodePath("NextTurnButton")
 
 [node name="TextureRect" type="TextureRect" parent="."]
 layout_mode = 1
@@ -23,9 +25,6 @@ metadata/_edit_lock_ = true
 
 [node name="Battlers" type="Node2D" parent="."]
 
-[node name="CharacterNode" parent="Battlers" instance=ExtResource("2_r5l0u")]
-position = Vector2(68, 74)
-scale = Vector2(0.5, 0.5)
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -48,3 +47,16 @@ text = "Guard"
 unique_name_in_owner = true
 layout_mode = 2
 text = "Skip"
+
+[node name="BattleLog" type="RichTextLabel" parent="."]
+layout_mode = 2
+offset_left = 50.0
+offset_top = 650.0
+offset_right = 1100.0
+offset_bottom = 750.0
+
+[node name="NextTurnButton" type="Button" parent="."]
+layout_mode = 2
+offset_left = 900.0
+offset_top = 760.0
+text = "Next"

--- a/game.tscn
+++ b/game.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://i0oq6chllo6s"]
+[gd_scene load_steps=2 format=3 uid="uid://i0oq6chllo6s"]
 
 [ext_resource type="Script" uid="uid://cmtacfc1vsv87" path="res://Game.cs" id="1_80nbo"]
-[ext_resource type="PackedScene" uid="uid://b4fruhiln6u1j" path="res://battle_scene.tscn" id="2_e2o6t"]
 
 [node name="Game" type="Control"]
 layout_mode = 3
@@ -41,8 +40,5 @@ layout_mode = 2
 custom_minimum_size = Vector2(0, 250)
 layout_mode = 2
 
-[node name="BattleScene" parent="PanelContainer/MarginContainer" instance=ExtResource("2_e2o6t")]
-visible = false
-layout_mode = 2
 
 [connection signal="pressed" from="PanelContainer/MarginContainer/VBoxContainer/btnKampf1" to="." method="_on_btn_kampf_1_pressed"]


### PR DESCRIPTION
## Summary
- load the correct battle scene when a fight starts
- spawn player, bear, and wolf when `btnKampf1` is pressed
- allow `CharacterData` to store a portrait texture
- pass that image to `CharacterNode` when creating nodes
- assign Map, BattleLog and NextTurnButton in `battle_scene.tscn`
- remove the preloaded BattleScene from `game.tscn`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68422462793c833282a13a36804e35b8