### PR TITLE
Fix null reference in CharacterNode

### DIFF
--- a/Scripts/battlesystem/CharacterNode.cs
+++ b/Scripts/battlesystem/CharacterNode.cs
@@ -76,7 +76,14 @@ public partial class CharacterNode : Node2D
         data.Node = this;
         if (data.CharacterImage != null)
             CharacterImage = data.CharacterImage;
-        UpdateUI();
+
+        // UpdateUI will be called in _Ready() once the node is fully
+        // initialized. Avoid calling it here when UI nodes are not yet
+        // available.
+        if (_hpBar != null && _manaBar != null)
+        {
+            UpdateUI();
+        }
     }
 
     public void UpdateUI()


### PR DESCRIPTION
## Summary
- avoid calling `UpdateUI()` before `_Ready()` initializes the progress bars

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422a5b240083329abe0e3981f79b0c