### PR TITLE
Fix NullReference when instantiating battle scene

### DIFF
--- a/Game.cs
+++ b/Game.cs
@@ -22,10 +22,9 @@ public partial class Game : Control
 
         var scene = GD.Load<PackedScene>("res://battle_scene.tscn");
         battleScene = scene.Instantiate<BattleScene>();
+        MainContent.AddChild(battleScene);
         // Optional: Charakterdaten an Szene übergeben
         battleScene.Setup(playerCharacters, enemies, OnBattleFinished);
-
-        MainContent.AddChild(battleScene);
     }
 
     public void OnBattleFinished()


### PR DESCRIPTION
## Summary
- ensure the BattleScene is added to the tree before calling `Setup`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68422b47c1288332ba75eaedd8835afa