### PR TITLE
Assign Battlers node automatically

### DIFF
--- a/BattleScene.cs
+++ b/BattleScene.cs
@@ -89,6 +89,12 @@ public partial class BattleScene : Control
 
     public override void _Ready()
     {
+        if (Map == null)
+        {
+            // Assign the Battlers node if not linked via the inspector
+            Map = GetNode<Node2D>("%Battlers");
+        }
+
         if (NextTurnButton != null)
             NextTurnButton.Pressed += OnNextTurn;
     }

--- a/battle_scene.tscn
+++ b/battle_scene.tscn
@@ -24,6 +24,8 @@ grow_vertical = 2
 metadata/_edit_lock_ = true
 
 [node name="Battlers" type="Node2D" parent="."]
+unique_name_in_owner = true
+position = Vector2(0, 0)
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- mark Battlers node as unique so it can be retrieved by name
- assign Battlers node in `_Ready` if not linked through the inspector

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68422fd6240883328a7c44616bd5875d