### PR TITLE
Add character name display

### DIFF
--- a/Scripts/battlesystem/CharacterNode.cs
+++ b/Scripts/battlesystem/CharacterNode.cs
@@ -5,17 +5,19 @@ using System.Runtime.CompilerServices;
 public partial class CharacterNode : Node2D
 {
     [Export] public Texture2D CharacterImage;
-    private TextureRect _image;
+    private Sprite2D _image;
     private ProgressBar _hpBar;
     private ProgressBar _manaBar;
+    private Label _nameLabel;
 
     public CharacterData Data;
 
     public override void _Ready()
     {
-        _image = GetNode<TextureRect>("%CharacterTexture");
+        _image = GetNode<Sprite2D>("%CharacterTexture");
         _hpBar = GetNode<ProgressBar>("%HPBar");
         _manaBar = GetNode<ProgressBar>("%ManaBar");
+        _nameLabel = GetNode<Label>("%NameLabel");
 
         if (CharacterImage != null)
             _image.Texture = CharacterImage;
@@ -37,6 +39,8 @@ public partial class CharacterNode : Node2D
         _hpBar.Value = Data.CurrentHP;
         _manaBar.MaxValue = Data.MaxMana;
         _manaBar.Value = Data.CurrentMana;
+        if (_nameLabel != null)
+            _nameLabel.Text = Data.Name;
     }
 
     public static CharacterNode Create(CharacterData data)

--- a/Scripts/battlesystem/CharacterNode.tscn
+++ b/Scripts/battlesystem/CharacterNode.tscn
@@ -55,7 +55,7 @@ environment = SubResource("Environment_xed63")
 position = Vector2(110, 206)
 shape = SubResource("CapsuleShape2D_o6dxo")
 
-[node name="CharacterSprite" type="Sprite2D" parent="CharacterBody2D"]
+[node name="CharacterTexture" type="Sprite2D" parent="CharacterBody2D"]
 unique_name_in_owner = true
 material = SubResource("ShaderMaterial_o6dxo")
 position = Vector2(109, 210)
@@ -74,8 +74,14 @@ theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 
+
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
 layout_mode = 2
+
+[node name="NameLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Name"
 
 [node name="HPBar" type="ProgressBar" parent="PanelContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true

--- a/tests/Rundenbasierteskampfsystemprototyp.Tests/CharacterDataTests.cs
+++ b/tests/Rundenbasierteskampfsystemprototyp.Tests/CharacterDataTests.cs
@@ -2,6 +2,13 @@ using Xunit;
 
 public class CharacterDataTests
 {
+    [Fact]
+    public void Name_IsStored()
+    {
+        var character = new CharacterData("TestName", 10, 5, 1, 1, 1);
+        Assert.Equal("TestName", character.Name);
+    }
+
     [Theory]
     [InlineData(1, true, false)]
     [InlineData(0, false, true)]


### PR DESCRIPTION
## Summary
- show each character's name above the HP bar
- access the character's sprite correctly
- test CharacterData name property

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434c60b50883329837cc5213ead1b7