### PR TITLE
Improve BattleScene log

### DIFF
--- a/Scripts/battlesystem/BattleManager.cs
+++ b/Scripts/battlesystem/BattleManager.cs
@@ -72,7 +72,13 @@ public class BattleManager
         target.CurrentHP = Math.Max(0, target.CurrentHP - damage);
         log?.AppendText($"\n{attacker.Name} greift {target.Name} an und verursacht {damage} Schaden.");
         if (target.IsDead)
-            log?.AppendText($"\n{target.Name} wurde besiegt.");
+        {
+            log?.AppendText($"\n{target.Name} hat keine HP mehr und wurde besiegt.");
+        }
+        else
+        {
+            log?.AppendText($"\n{target.Name} hat noch {target.CurrentHP}/{target.MaxHP} HP.");
+        }
     }
 
     public void Guard(CharacterData actor)

--- a/battle_scene.tscn
+++ b/battle_scene.tscn
@@ -48,10 +48,10 @@ text = "Skip"
 
 [node name="BattleLog" type="RichTextLabel" parent="."]
 layout_mode = 2
-offset_left = 50.0
-offset_top = 650.0
+offset_left = 720.0
+offset_top = 536.0
 offset_right = 1100.0
-offset_bottom = 750.0
+offset_bottom = 642.0
 
 [node name="NextTurnButton" type="Button" parent="."]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- position battle log beside action buttons
- show remaining HP and defeat message in Attack()

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6844728fae9c833280a90a1757b7c830