### PR TITLE
Integrate combat AI into turns

### DIFF
--- a/Game.cs
+++ b/Game.cs
@@ -48,6 +48,9 @@ public partial class Game : Control
         var bear = new CharacterData("Bär",false, 200, 0, 5, 8, 10, bearImage);
         var wolf = new CharacterData("Wolf",false, 50, 0, 20, 5, 5, wolfImage);
 
+        bear.CombatAI = new RandomCombatAI();
+        wolf.CombatAI = new RandomCombatAI();
+
         StartBattle(new List<CharacterData> { player }, new List<CharacterData> { bear, wolf });
 
     }

--- a/Scripts/battlesystem/BattleManager.cs
+++ b/Scripts/battlesystem/BattleManager.cs
@@ -124,7 +124,18 @@ public class BattleManager
         var actor = StepTurn(initiativeGauge, rounds);
 
         actor.RemoveExpiredBuffs(actor.Round);
-        log.AppendText($"\n{actor.Name} ist am Zug.");
+        log?.AppendText($"\n{actor.Name} ist am Zug.");
+
+        var context = new BattleContext
+        {
+            Enemylist = playerCharacters.Contains(actor) ? enemies : playerCharacters,
+            Turnnumber = actor.Round
+        };
+
+        if (!actor.IsPlayerCharacter && actor.CombatAI != null)
+        {
+            actor.CombatAI.DecideNextAction(context);
+        }
 
         CharacterData target = null;
         if (playerCharacters.Contains(actor))

--- a/Scripts/battlesystem/CharacterData.cs
+++ b/Scripts/battlesystem/CharacterData.cs
@@ -28,6 +28,18 @@ public class CharacterData
 
     public CharacterNode Node { get; set; }
 
+    public ICombatAI? CombatAI
+    {
+        get => combatAI;
+        set
+        {
+            combatAI = value;
+            combatAI?.Initialize(this);
+        }
+    }
+
+    private ICombatAI? combatAI;
+
     public List<IAbility> Abilities { get; } = new();
 
     private readonly List<Buff> buffs = new();

--- a/tests/Rundenbasierteskampfsystemprototyp.Tests/BattleManagerTests.cs
+++ b/tests/Rundenbasierteskampfsystemprototyp.Tests/BattleManagerTests.cs
@@ -13,4 +13,30 @@ public class BattleManagerTests
         var order = manager.UpcomingTurns.Take(6).ToList();
         Assert.Equal(new[]{a, a, b, a, a, b}, order);
     }
+
+    private class DummyAI : ICombatAI
+    {
+        public bool DecideCalled { get; private set; }
+        public void Initialize(CharacterData self) { }
+        public BattleAction DecideNextAction(BattleContext context)
+        {
+            DecideCalled = true;
+            return new BattleAction();
+        }
+    }
+
+    [Fact]
+    public void ExecuteTurn_Calls_AI_For_Enemy()
+    {
+        var player = new CharacterData("P", true, 10, 5, 1, 1, 1);
+        var enemy = new CharacterData("E", false, 10, 5, 100, 1, 1);
+        var ai = new DummyAI();
+        enemy.CombatAI = ai;
+
+        var manager = new BattleManager(new List<CharacterData>{player}, new List<CharacterData>{enemy}, null!, () => { });
+
+        manager.ExecuteTurn();
+
+        Assert.True(ai.DecideCalled);
+    }
 }

--- a/tests/Rundenbasierteskampfsystemprototyp.Tests/CharacterDataTests.cs
+++ b/tests/Rundenbasierteskampfsystemprototyp.Tests/CharacterDataTests.cs
@@ -36,4 +36,33 @@ public class CharacterDataTests
         character.AdvanceRound();
         Assert.Equal(1, character.Round);
     }
+
+    private class DummyAI : ICombatAI
+    {
+        public CharacterData? InitializedWith { get; private set; }
+        public bool DecideCalled { get; private set; }
+
+        public void Initialize(CharacterData self)
+        {
+            InitializedWith = self;
+        }
+
+        public BattleAction DecideNextAction(BattleContext context)
+        {
+            DecideCalled = true;
+            return new BattleAction();
+        }
+    }
+
+    [Fact]
+    public void Setting_CombatAI_Initializes_AI()
+    {
+        var character = new CharacterData("Test", false, 10, 5, 1, 1, 1);
+        var ai = new DummyAI();
+
+        character.CombatAI = ai;
+
+        Assert.Equal(ai, character.CombatAI);
+        Assert.Equal(character, ai.InitializedWith);
+    }
 }


### PR DESCRIPTION
## Summary
- allow `CharacterData` to hold a combat AI and initialize it
- invoke AI decision making for enemies during `ExecuteTurn`
- assign `RandomCombatAI` to sample enemies in `Game`
- test AI initialization and that `ExecuteTurn` calls enemy AI

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68462f98767083328b7e9bcc9511e3ee