### PR TITLE
Add ability grid and async player actions

### DIFF
--- a/Scripts/battlesystem/Abilitys/AttackAbility.cs
+++ b/Scripts/battlesystem/Abilitys/AttackAbility.cs
@@ -6,5 +6,7 @@ public class AttackAbility : BasicAbility
         Scalestat = CharacterStat.Attack;
         Faktor = 1;
         ResourceCost = 0;
+        Name = "Attack";
+        RequiresTarget = true;
    }
 }

--- a/Scripts/battlesystem/Abilitys/BasicAbility.cs
+++ b/Scripts/battlesystem/Abilitys/BasicAbility.cs
@@ -5,4 +5,8 @@ public class BasicAbility
     public CharacterStat Scalestat { get; set; }
     public float Faktor { get; set; }
     public int ResourceCost { get; set; }
+    /// <summary>
+    /// Some abilities do not require a manual target selection.
+    /// </summary>
+    public bool RequiresTarget { get; set; } = true;
 }

--- a/Scripts/battlesystem/BattleAction.cs
+++ b/Scripts/battlesystem/BattleAction.cs
@@ -3,12 +3,13 @@ using System.Dynamic;
 
 public class BattleAction
 {
-    public BattleAction(BasicAbility ability, CharacterData target)
+    public BattleAction(BasicAbility ability, CharacterData? target = null)
     {
-        this.Ability = ability;
-        this.Target = target;
+        Ability = ability;
+        Target = target;
     }
+
     public BasicAbility Ability { get; set; }
-    public CharacterData Target { get; set; }
+    public CharacterData? Target { get; set; }
 
 }

--- a/Scripts/battlesystem/CharacterData.cs
+++ b/Scripts/battlesystem/CharacterData.cs
@@ -116,9 +116,4 @@ public class CharacterData
         this.CurrentHP -= (dmg - GetStat(CharacterStat.Defence, Turn));
     }
 
-    internal async Task ExcecuteTurn(BattleContext context)
-    {
-        //TODO: wait for finished interface actions of player
-    }
-
 }

--- a/Scripts/battlesystem/CharacterNode.cs
+++ b/Scripts/battlesystem/CharacterNode.cs
@@ -4,6 +4,8 @@ using System.Runtime.CompilerServices;
 
 public partial class CharacterNode : Node2D
 {
+    [Signal]
+    public delegate void CharacterClicked(CharacterNode node);
     [Export] public Texture2D CharacterImage;
     private Sprite2D _sprite;
     private bool _isHovered = false;
@@ -18,7 +20,7 @@ public partial class CharacterNode : Node2D
 
     public override void _Ready()
     {
-        _sprite = GetNode<Sprite2D>("%CharacterTexture");        
+        _sprite = GetNode<Sprite2D>("%CharacterTexture");
         _hpBar = GetNode<ProgressBar>("%HPBar");
         _manaBar = GetNode<ProgressBar>("%ManaBar");
         _nameLabel = GetNode<Label>("%NameLabel");
@@ -29,8 +31,19 @@ public partial class CharacterNode : Node2D
         _shadermaterial.Shader = shader;
         _sprite.Material = _shadermaterial;
 
+        var body = GetNode<CharacterBody2D>("CharacterBody2D");
+        body.InputEvent += OnBodyInput;
+
         UpdateUI();
         UpdateOutline();
+    }
+
+    private void OnBodyInput(Node viewport, InputEvent @event, long shapeIdx)
+    {
+        if (@event is InputEventMouseButton mouse && mouse.Pressed && mouse.ButtonIndex == MouseButton.Left)
+        {
+            EmitSignal(SignalName.CharacterClicked, this);
+        }
     }
 
     private void _on_character_body_2d_mouse_entered()

--- a/battle_scene.tscn
+++ b/battle_scene.tscn
@@ -35,32 +35,17 @@ offset_top = 10.0
 offset_right = 980.0
 offset_bottom = 60.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="AbilityScroll" type="ScrollContainer" parent="."]
 layout_mode = 2
 offset_left = 351.0
 offset_top = 486.0
 offset_right = 708.0
 offset_bottom = 635.0
 
-[node name="NextTurnButton" type="Button" parent="VBoxContainer"]
+[node name="AbilityGrid" type="GridContainer" parent="AbilityScroll"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Next"
-
-[node name="btnAngriff" type="Button" parent="VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Angriff"
-
-[node name="btnGuard" type="Button" parent="VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Guard"
-
-[node name="btnSkip" type="Button" parent="VBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-text = "Skip"
+columns = 1
 
 [node name="BattleLog" type="RichTextLabel" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- extend ability system with `RequiresTarget`
- allow nullable targets in `BattleAction`
- fire event from `BattleManager` to request player action
- add clickable characters and ability grid UI in `BattleScene`
- remove outdated buttons from scene file

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f37b425c8332aeabb482dbe36ac8