### PR TITLE
Add damage variance to AttackAbility

### DIFF
--- a/Scripts/battlesystem/Abilitys/AttackAbility.cs
+++ b/Scripts/battlesystem/Abilitys/AttackAbility.cs
@@ -1,5 +1,6 @@
 public class AttackAbility : BasicAbility
 {
+    private readonly System.Random random = new();
     public AttackAbility()
     {
         Type = AbilityType.Attack;
@@ -9,4 +10,13 @@ public class AttackAbility : BasicAbility
         Name = "Attack";
         RequiresTarget = true;
    }
+
+    /// <summary>
+    /// Calculates damage with a random multiplier between 0.75 and 1.25.
+    /// </summary>
+    public override float CalculateDamage(CharacterData attacker)
+    {
+        float variance = (float)(random.NextDouble() * 0.5 + 0.75); // 0.75 - 1.25
+        return Faktor * attacker.GetStat(Scalestat, attacker.Turn) * variance;
+    }
 }

--- a/Scripts/battlesystem/Abilitys/BasicAbility.cs
+++ b/Scripts/battlesystem/Abilitys/BasicAbility.cs
@@ -9,4 +9,16 @@ public class BasicAbility
     /// Some abilities do not require a manual target selection.
     /// </summary>
     public bool RequiresTarget { get; set; } = true;
+
+    /// <summary>
+    /// Calculates the damage this ability deals when used by the given attacker.
+    /// The base implementation simply returns the scaled stat multiplied by
+    /// <see cref="Faktor"/>.
+    /// </summary>
+    /// <param name="attacker">The character using the ability.</param>
+    /// <returns>The damage amount.</returns>
+    public virtual float CalculateDamage(CharacterData attacker)
+    {
+        return Faktor * attacker.GetStat(Scalestat, attacker.Turn);
+    }
 }

--- a/Scripts/battlesystem/BattleManager.cs
+++ b/Scripts/battlesystem/BattleManager.cs
@@ -143,8 +143,8 @@ public class BattleManager
         var target = action.Target;
         if (action.Ability.Type == AbilityType.Attack)
         {
-            var dmg = action.Ability.Faktor * character.GetStat(action.Ability.Scalestat, character.Turn);
-            log?.AppendText($"\n{character.Name} attacks with {action.Ability.Name} and  {dmg} points.");            
+            var dmg = action.Ability.CalculateDamage(character);
+            log?.AppendText($"\n{character.Name} attacks with {action.Ability.Name} and  {dmg} points.");
             action.Target.RecieveDmg(dmg, log);
         }
     }

--- a/tests/Rundenbasierteskampfsystemprototyp.Tests/AttackAbilityTests.cs
+++ b/tests/Rundenbasierteskampfsystemprototyp.Tests/AttackAbilityTests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+
+public class AttackAbilityTests
+{
+    [Fact]
+    public void CalculateDamage_WithinExpectedRange()
+    {
+        var attacker = new CharacterData("Attacker", true, 100, 0, 10, 20, 5);
+        var ability = new AttackAbility();
+        var baseDmg = attacker.GetStat(CharacterStat.Attack, attacker.Turn);
+        for (int i = 0; i < 20; i++)
+        {
+            var dmg = ability.CalculateDamage(attacker);
+            Assert.InRange(dmg, 0.75f * baseDmg, 1.25f * baseDmg);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow `AttackAbility` to deal 75%-125% of its normal damage
- add `CalculateDamage` helper in `BasicAbility`
- use `CalculateDamage` in `BattleManager`
- add unit test for the new random damage

## Testing
- `dotnet build 'Rundenbasiertes kampfsystem prototyp.sln'`
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6871794973dc8332a279650644ed7e3a